### PR TITLE
Ensure sized on associated methods

### DIFF
--- a/named_type/Cargo.toml
+++ b/named_type/Cargo.toml
@@ -10,5 +10,3 @@ homepage = "https://github.com/cjhowe7/named_type"
 repository = "https://github.com/cjhowe7/named_type"
 
 [dependencies]
-named_type_derive = { path = "../named_type_derive" }
-

--- a/named_type/Cargo.toml
+++ b/named_type/Cargo.toml
@@ -10,3 +10,5 @@ homepage = "https://github.com/cjhowe7/named_type"
 repository = "https://github.com/cjhowe7/named_type"
 
 [dependencies]
+named_type_derive = { path = "../named_type_derive" }
+

--- a/named_type/src/lib.rs
+++ b/named_type/src/lib.rs
@@ -55,6 +55,14 @@
 //! # }
 //! ```
 
+#[allow(unused_imports)]
+#[macro_use]
+extern crate named_type_derive;
+
+#[doc(hidden)]
+pub use named_type_derive::*;
+
+
 /// A trait for getting the name of a type
 pub trait NamedType {
     /// Returns the canonical name with the fully qualified module name for the

--- a/named_type/src/lib.rs
+++ b/named_type/src/lib.rs
@@ -55,14 +55,6 @@
 //! # }
 //! ```
 
-#[allow(unused_imports)]
-#[macro_use]
-extern crate named_type_derive;
-
-#[doc(hidden)]
-pub use named_type_derive::*;
-
-
 /// A trait for getting the name of a type
 pub trait NamedType {
     /// Returns the canonical name with the fully qualified module name for the

--- a/named_type/src/lib.rs
+++ b/named_type/src/lib.rs
@@ -59,8 +59,12 @@
 pub trait NamedType {
     /// Returns the canonical name with the fully qualified module name for the
     /// given type
-    fn type_name() -> &'static str;
+    fn type_name() -> &'static str
+    where
+        Self: Sized;
 
     /// Returns a user-friendly short name for the given type
-    fn short_type_name() -> &'static str;
+    fn short_type_name() -> &'static str
+    where
+        Self: Sized;
 }

--- a/named_type_derive/src/lib.rs
+++ b/named_type_derive/src/lib.rs
@@ -34,13 +34,15 @@ fn find_prefix_suffix(props: &Vec<NestedMetaItem>) -> Option<(&str, &str)> {
                 ident == "short_prefix"
             }
             _ => false,
-        }).and_then(|item| match item {
+        })
+        .and_then(|item| match item {
             &NestedMetaItem::MetaItem(MetaItem::NameValue(_, ref value)) => match value {
                 &Lit::Str(ref string, _) => Some(string.as_ref()),
                 _ => None,
             },
             _ => None,
-        }).unwrap_or("");
+        })
+        .unwrap_or("");
 
     let suffix = props
         .iter()
@@ -49,13 +51,15 @@ fn find_prefix_suffix(props: &Vec<NestedMetaItem>) -> Option<(&str, &str)> {
                 ident.to_string() == "short_suffix"
             }
             _ => false,
-        }).and_then(|item| match item {
+        })
+        .and_then(|item| match item {
             &NestedMetaItem::MetaItem(MetaItem::NameValue(_, ref value)) => match value {
                 &Lit::Str(ref string, _) => Some(string.as_ref()),
                 _ => None,
             },
             _ => None,
-        }).unwrap_or("");
+        })
+        .unwrap_or("");
 
     Some((prefix, suffix))
 }
@@ -70,15 +74,17 @@ fn named_type_derive(ast: syn::MacroInput) -> quote::Tokens {
             .find(|attr| match &attr.value {
                 &MetaItem::List(ref ident, _) => ident == "named_type",
                 _ => false,
-            }).and_then(|attr| match &attr.value {
+            })
+            .and_then(|attr| match &attr.value {
                 &MetaItem::List(_, ref props) => find_prefix_suffix(props),
                 _ => None,
-            }).unwrap_or(("", ""))
+            })
+            .unwrap_or(("", ""))
     };
 
     let short_type_name: String = format!("{}{}{}", prefix, name, suffix);
 
-    quote!{
+    quote! {
         impl #impl_generics NamedType for #name #ty_generics #where_clause {
             fn type_name() -> &'static str {
                 concat!(module_path!(), "::", stringify!(#name))

--- a/named_type_test/src/lib.rs
+++ b/named_type_test/src/lib.rs
@@ -1,4 +1,6 @@
 extern crate named_type;
+#[macro_use]
+extern crate named_type_derive;
 
 use named_type::NamedType;
 

--- a/named_type_test/src/lib.rs
+++ b/named_type_test/src/lib.rs
@@ -52,11 +52,11 @@ fn test_suffix() {
 
 #[test]
 fn test_ensure_that_structs_could_be_made_into_objects() {
-    let list_of_boxed_NamedType: Vec<Box<NamedType>> = vec![
+    let list_of_boxed_named_type: Vec<Box<NamedType>> = vec![
         Box::new(MyStruct {}),
         Box::new(MyEnum::V1),
         Box::new(Prefixed::V1),
         Box::new(Suffixed {}),
     ];
-    assert_eq!(list_of_boxed_NamedType.len(), 4);
+    assert_eq!(list_of_boxed_named_type.len(), 4);
 }

--- a/named_type_test/src/lib.rs
+++ b/named_type_test/src/lib.rs
@@ -1,6 +1,4 @@
 extern crate named_type;
-#[macro_use]
-extern crate named_type_derive;
 
 use named_type::NamedType;
 

--- a/named_type_test/src/lib.rs
+++ b/named_type_test/src/lib.rs
@@ -16,7 +16,9 @@ fn test_struct() {
 
 #[allow(dead_code)]
 #[derive(NamedType)]
-enum MyEnum {}
+enum MyEnum {
+    V1
+}
 
 #[test]
 fn test_enum() {
@@ -27,7 +29,9 @@ fn test_enum() {
 #[allow(dead_code)]
 #[derive(NamedType)]
 #[named_type(short_prefix = "Pre")]
-enum Prefixed {}
+enum Prefixed {
+    V1
+}
 
 #[test]
 fn test_prefix() {
@@ -44,4 +48,15 @@ struct Suffixed {}
 fn test_suffix() {
     assert_eq!(Suffixed::type_name(), concat!(module_path!(), "::Suffixed"));
     assert_eq!(Suffixed::short_type_name(), "Suffixed_suffix");
+}
+
+#[test]
+fn test_ensure_that_structs_could_be_made_into_objects() {
+    let list_of_boxed_NamedType: Vec<Box<NamedType>> = vec![
+        Box::new(MyStruct {}),
+        Box::new(MyEnum::V1),
+        Box::new(Prefixed::V1),
+        Box::new(Suffixed {}),
+    ];
+    assert_eq!(list_of_boxed_NamedType.len(), 4);
 }


### PR DESCRIPTION
Associated methods needs to be available only for `Sized` implementations.
As far as I can tell this is a common pattern for traits that adds _associated methods_ to structs (ie. [Default](https://github.com/rust-lang/rust/blob/d6525ef539a04cb43de40080bdabc5f2f5a4a197/src/libcore/default.rs#L84), [From](https://github.com/rust-lang/rust/blob/d6525ef539a04cb43de40080bdabc5f2f5a4a197/src/libcore/convert.rs#L356), etc.)

The main rationale of this change is to allow `NamedType` derived structs to be stored into structures like `Vec<Box<a_trait_name>>`

The added test case would fail to compile if the changes into `named_type/src/lib.rs` would be reverted, in such way we can prevent eventual regressions.

I've also added `named_type_derive` dependency in `named_type` such that users of this crate will need to only add `named_type` dependency in cargo.
Without doing that users were _forced_ to use `named_type` and `named_type_derive` and to ensure that both were defined with the same version.